### PR TITLE
feat!: add `get_arg[T]` to parse JS args of any type

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ const html = '<!DOCTYPE html>
 fn my_v_func(e &webview.Event) string {
 	println('Hello from V from V!')
 	e.eval("console.log('Hello from V from JS!');")
-	str_arg := e.string(0) // Get string arg at index `0`
+	str_arg := e.get_arg[string](0) or { '' } // Get string arg at index `0`
 	return str_arg + ' Hello back from V!'
 }
 

--- a/examples/project-structure/src/api.v
+++ b/examples/project-structure/src/api.v
@@ -25,7 +25,10 @@ fn toggle(_ &Event, mut app App) bool {
 
 // Handles received arguments.
 fn login(e &Event) string {
-	name := e.string(0)
+	name := e.get_arg[string](0) or {
+		eprintln(err)
+		return ''
+	}
 	println('Hello ${name}!')
 	return 'Data received: Check your terminal.'
 }

--- a/examples/v-js-interop-app/main.v
+++ b/examples/v-js-interop-app/main.v
@@ -35,7 +35,10 @@ fn toggle(_ &Event, mut app App) bool {
 
 // Handles received arguments.
 fn login(e &Event) string {
-	name := e.string(0)
+	name := e.get_arg[string](0) or {
+		eprintln(err)
+		return ''
+	}
 	println('Hello ${name}!')
 	return 'Data received: Check your terminal.'
 }

--- a/examples/v-js-interop-simple/main.v
+++ b/examples/v-js-interop-simple/main.v
@@ -38,7 +38,10 @@ fn interop(e &webview.Event) voidptr {
 
 // Returns a value to JS.
 fn double(e &webview.Event) int {
-	return e.int(0) * 2
+	return e.get_arg[int](0) or {
+		eprintln(err)
+		return 0
+	} * 2
 }
 
 fn main() {

--- a/src/lib.v
+++ b/src/lib.v
@@ -207,37 +207,57 @@ pub fn (e &Event) eval(code string) {
 	C.webview_eval(e.instance, &char(code.str))
 }
 
-// string decodes and returns the event argument with the given index as string.
+// get_arg parses the JavaScript argument into a V data type.
+pub fn (e &Event) get_arg[T](idx int) !T {
+	$if T is int {
+		return e.get_args_json[T](idx)!
+	} $else $if T is string {
+		return e.get_args_json[T](idx)!
+	} $else $if T is bool {
+		return e.get_args_json[T](idx)!
+	} $else {
+		return e.get_complex_args_json[T](idx)!
+	}
+}
+
+// string parses the JavaScript argument with the given index as string.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[string](0)!`']
 pub fn (e &Event) string(idx usize) string {
 	return e.args_json[string]() or { return '' }[int(idx)] or { '' }
 }
 
-// int decodes and returns the argument with the given index as integer.
+// int parses the JavaScript argument with the given index as integer.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[int](0)!`']
 pub fn (e &Event) int(idx usize) int {
 	return e.args_json[int]() or { return 0 }[int(idx)] or { return 0 }
 }
 
-// bool decodes and returns the argument with the given index as boolean.
+// bool parses the JavaScript argument with the given index as boolean.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[bool](0)!`']
 pub fn (e &Event) bool(idx usize) bool {
 	return e.args_json[bool]() or { return false }[int(idx)] or { return false }
 }
 
-// string_opt decodes and returns the argument with the given index as string option.
+// string_opt parses the JavaScript argument with the given index as string option.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[string](0)!`']
 pub fn (e &Event) string_opt(idx usize) ?string {
 	return e.args_json[string]() or { return none }[int(idx)] or { return none }
 }
 
-// int_opt decodes and returns the argument with the given index as integer option.
+// int_opt parses the JavaScript argument with the given index as integer option.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[int](0)!`']
 pub fn (e &Event) int_opt(idx usize) ?int {
 	return e.args_json[int]() or { return none }[int(idx)] or { return none }
 }
 
 // bool_opt decodes and return the argument with the given index as boolean option.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[bool](0)!`']
 pub fn (e &Event) bool_opt(idx usize) ?bool {
 	return e.args_json[bool]() or { return none }[int(idx)] or { return none }
 }
 
-// decode decodes and returns the argument with the given index into a V data type.
+// decode parses the JavaScript argument with the given index into a V data type.
+[deprecated: 'will be removed with v0.7; use `get_arg[T](idx int) !T` instead. E.g: `e.get_arg[MyStruct](0)!`']
 pub fn (e &Event) decode[T](idx usize) !T {
 	return json.decode(T, e.string(idx)) or { return error('Failed decoding arguments. ${err}') }
 }


### PR DESCRIPTION
- Adds a new `pub fn (e &Event) get_arg[T](idx int) !T` method to make JS arg to V type parsing more explicit and uniform.
- The method embraces error handling by default for safer code. E.g. for JS null values when args where missed or when decoding of args failed, e.g. when erroneous args where passed.
- Allows to pass negative indices to get the arg index from the last position. E.g. `get_arg[string](-1)` parses the last arg that a V function received from JS as string.
- Marks other arg parsing methods like `e.string(0)`, `e.decode[MyStruct](0)` etc. as deprecated with version 0.7.0.
- Extends test coverage.