### PR TITLE
feat: add `bind_opt` and `bind_opt_with_ctx`

### DIFF
--- a/examples/project-structure/src/api.v
+++ b/examples/project-structure/src/api.v
@@ -5,7 +5,7 @@ fn (mut app App) bind(w &Webview) {
 	// The first string argument is the functions name in the JS frontend.
 	// Use JS's `camelCase` convention or distinct identifiers if you prefer it.
 	w.bind('get_settings', app.get_settings)
-	w.bind_ctx('toggle_setting', toggle, app) // Alternatively use the ctx ptr to pass a struct.
+	w.bind_with_ctx('toggle_setting', toggle, app) // Alternatively use the ctx ptr to pass a struct.
 	w.bind('login', login)
 	w.bind('fetch_news', fetch_news)
 }
@@ -17,7 +17,7 @@ fn (app App) get_settings(_ &Event) Settings {
 }
 
 // Returns a value when it's called from JS.
-// This examples uses bind_ctx, adding the App struct as context argument.
+// This examples uses `bind_with_ctx` to add the App struct as context argument.
 fn toggle(_ &Event, mut app App) bool {
 	app.settings.toggle = !app.settings.toggle
 	dump(app.settings.toggle)

--- a/examples/v-js-interop-app/main.v
+++ b/examples/v-js-interop-app/main.v
@@ -26,7 +26,7 @@ fn (app App) get_settings(_ &Event) Settings {
 }
 
 // Returns a value when it's called from JS.
-// This examples uses bind_ctx, adding the App struct as context argument.
+// This examples uses `bind_with_ctx` to add the App struct as context argument.
 fn toggle(_ &Event, mut app App) bool {
 	app.settings.toggle = !app.settings.toggle
 	dump(app.settings.toggle)
@@ -78,7 +78,7 @@ fn main() {
 	// The first string argument is the functions name in the JS frontend.
 	// Use JS's `camelCase` convention or distinct identifiers if you prefer it.
 	w.bind('get_settings', app.get_settings)
-	w.bind_ctx('toggle_setting', toggle, &app) // Alternatively use the ctx ptr to pass a struct.
+	w.bind_with_ctx('toggle_setting', toggle, &app) // Alternatively use the ctx ptr to pass a struct.
 	w.bind('login', login)
 	w.bind('fetch_news', fetch_news)
 

--- a/src/lib.v
+++ b/src/lib.v
@@ -176,7 +176,7 @@ pub fn (w &Webview) bind_ctx[T](name string, func fn (e &Event, ctx voidptr) T, 
 		e := unsafe { &Event{w, event_id, args} }
 		spawn fn [func, ctx] [T](e &Event) {
 			result := func(e, ctx)
-			e.@return(result)
+			e.@return(result, .value)
 		}(e.async())
 	}, ctx)
 }
@@ -188,7 +188,7 @@ pub fn (w &Webview) bind_with_ctx[T](name string, func fn (e &Event, ctx voidptr
 		e := unsafe { &Event{w, event_id, args} }
 		spawn fn [func, ctx] [T](e &Event) {
 			result := func(e, ctx)
-			e.@return(result)
+			e.@return(result, .value)
 		}(e.async())
 	}, ctx)
 }

--- a/src/utils.v
+++ b/src/utils.v
@@ -2,8 +2,13 @@ module webview
 
 import json
 
+enum ReturnKind {
+	value
+	error
+}
+
 // copy_char copies a C style string. The functions main use case is passing an `event_id &char`
-// to another thread. It helps to keep the event id available when executing `@return`
+// to another thread. It helps to keep the event id available when executing `@retrun`
 // from the spawned thread. Without copying the `event_id` might get obscured during garbage
 // collection and returning data to a calling JS function becomes error prone.
 fn copy_char(s &char) &char {
@@ -14,11 +19,11 @@ fn copy_char(s &char) &char {
 // be provided to allow the internal RPC engine to match the request and response.
 // If the status is zero - the result is expected to be a valid JSON value.
 // If the status is not zero - the result is an error JSON object.
-fn (e &Event) @return[T](result T, return_params ReturnParams) {
+fn (e &Event) @return[T](result T, kind ReturnKind) {
 	$if result is voidptr {
-		C.webview_return(e.instance, e.event_id, 0, &char(''.str))
+		C.webview_return(e.instance, e.event_id, int(kind), &char(''.str))
 	} $else {
-		C.webview_return(e.instance, e.event_id, 0, &char(json.encode(result).str))
+		C.webview_return(e.instance, e.event_id, int(kind), &char(json.encode(result).str))
 	}
 }
 


### PR DESCRIPTION
Allows to bind callbacks that can return errors to calling JS functions.

Marks `bind_ctx` as deprecated and informs to use `bind_with_ctx` instead.